### PR TITLE
Use actions instead of jQuery Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,39 +12,51 @@ Ember component for FroalaWysiwygEditor
 See [demo app source](https://github.com/ajackus/ember-froala/tree/master/tests/dummy/app) for example usage.
 
 * Controller example
-```
+```javascript
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  value: 'test',
 
-    value: 'test',
+  froalaEditor: {
+    params: {
+      inlineMode: true,
+      placeholder: 'Enter..',
+      allowHTML: true,
+      autosave: true,
+      autosaveInterval: 10000,
+        // For more params refer: 'https://www.froala.com/wysiwyg-editor/docs/options'
+    },
+  },
 
-    froalaEditor: {
-        params: {
-            inlineMode: true,
-            placeholder: 'Enter..',
-            allowHTML: true,
-            autosave: true,
-            autosaveInterval: 10000,
-            // For more params refer: 'https://www.froala.com/wysiwyg-editor/docs/options'
-        },
-
-        events: {
-            'blur' : function() { return alert('focusOut'); },
-            'focus' : function() { return alert('focused'); },
-            'contentChanged': function() { return alert('contentChanged'); },
-            'align': function() { return alert('aligned'); },
-            'afterPaste': function() { return alert('content pasted'); }
-            // For more events: 'https://www.froala.com/wysiwyg-editor/docs/events'
-        }
-    }
-    
+  actions: {
+    contentChanged: function(event, editor) {
+      console.log("Content Changed");
+      console.log(event);
+      console.log(editor);
+    },
+    focus: function(event, editor) {
+      console.log("Focus");
+      console.log(event);
+      console.log(editor);
+    },
+  },
 });
 ```
 
 * Template example
 
-`{{froala-editor params=froalaEditor.params value=value events=froalaEditor.events}}`
+```hbs
+{{froala-editor params=froalaEditor.params value=value focus=(action "focus") contentChanged=(action "contentChanged")}}
+```
+
+### Please Note:
+The `value` is only for the initial value of the field.
+It will not be updated when the user changes the text.
+If the underlying value changes while the component is active, the editor will not reflect the change.
+In order to get the values that the user changes, you will need to listen to the
+`contentChanged` action.
+
 
 ## License
 

--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/froala-editor';
+const { isFunction, proxy } = Ember.$;
 
 export default Ember.Component.extend({
     layout: layout,
@@ -8,18 +9,117 @@ export default Ember.Component.extend({
     _froala: null,
     params: {},
     value: null,
+    eventNames: [
+      'afterFileUpload',
+      'afterImageUpload',
+      'afterPaste',
+      'afterPasteCleanup',
+      'afterRemoveImage',
+      'afterSave',
+      'afterUploadPastedImage',
+      'align',
+      'backColor',
+      'badLink',
+      'beforeDeleteImage',
+      'beforeFileUpload',
+      'beforeImageUpload',
+      'beforePaste',
+      'beforeRemoveImage',
+      'beforeSave',
+      'beforeUploadPastedImage',
+      'blur',
+      'bold',
+      'cellDeleted',
+      'cellHorizontalSplit',
+      'cellInsertedAfter',
+      'cellInsertedBefore',
+      'cellVerticalSplit',
+      'cellsMerged',
+      'columnDeleted',
+      'columnInsertedAfter',
+      'columnInsertedBefore',
+      'contentChanged',
+      'fileError',
+      'fileUploaded',
+      'focus',
+      'fontFamily',
+      'fontSize',
+      'foreColor',
+      'formatBlock',
+      'getHTML',
+      'htmlHide',
+      'htmlShow',
+      'imageAltSet',
+      'imageDeleteError',
+      'imageDeleteSuccess',
+      'imageError',
+      'imageFloatedLeft',
+      'imageFloatedNone',
+      'imageFloatedRight',
+      'imageInserted',
+      'imageLinkInserted',
+      'imageLinkRemoved',
+      'imageLoaded',
+      'imageReplaced',
+      'imageResize',
+      'imageResizeEnd',
+      'imagesLoaded',
+      'imagesLoadError',
+      'indent',
+      'initialized',
+      'italic',
+      'linkInserted',
+      'linkRemoved',
+      'maxCharNumberExceeded',
+      'onPaste',
+      'orderedListInserted',
+      'outdent',
+      'redo',
+      'rowDeleted',
+      'rowInsertedAbove',
+      'rowInsertedBelow',
+      'saveError',
+      'selectAll',
+      'strikeThrough',
+      'subscript',
+      'superscript',
+      'tableDeleted',
+      'tableInserted',
+      'underline',
+      'undo',
+      'unorderedListInserted',
+      'videoError',
+      'videoFloatedLeft',
+      'videoFloatedNone',
+      'videoFloatedRight',
+      'videoInserted',
+      'videoRemoved',
+    ],
 
     didInsertElement: function() {
-        var _this = this,
-            froala = this.$().editable(this.get('params')),
-            events = this.get('events');
+        var froala = this.$().editable(this.get('params')),
+            events = this.get('eventNames');
 
-        this.$().editable('setHTML', this.get('value') || '', false);
+        const froalaElement = this.$();
+        froalaElement.editable('setHTML', this.get('value') || '', false);
 
-        for (var key in events) {
-            _this.$().on('editable.'+key, Ember.$.proxy(events[key], this));
-        }
+        events.forEach((key) => {
+          if(this.attrs[key]) {
+            froalaElement.on('editable.'+key, proxy(this.handleFroalaEvent, this));
+          }
+        });
+
         this.set('_froala', froala);
+    },
+
+    handleFroalaEvent: function(event, editor) {
+      const eventName = event.namespace;
+      const actionHandler = this.attrs[eventName];
+      if(isFunction(actionHandler)) {
+        actionHandler(event, editor);
+      } else {
+        this.sendAction(eventName, event, editor);
+      }
     },
 
     willDestroyElement: function() {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,27 +1,29 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-
     value: 'test',
 
     froalaEditor: {
-        params: {
-            inlineMode: true,
-            placeholder: 'Enter..',
-            allowHTML: true,
-            autosave: true,
-            autosaveInterval: 10000,
-            // For more params refer: 'https://www.froala.com/wysiwyg-editor/docs/options'
-        },
+      params: {
+        inlineMode: true,
+        placeholder: 'Enter..',
+        allowHTML: true,
+        autosave: true,
+        autosaveInterval: 10000,
+          // For more params refer: 'https://www.froala.com/wysiwyg-editor/docs/options'
+      },
+    },
 
-        events: {
-            'blur' : function() { return alert('focusOut'); },
-            'focus' : function() { return alert('focused'); },
-            'contentChanged': function() { return alert('contentChanged'); },
-            'align': function() { return alert('aligned'); },
-            'afterPaste': function() { return alert('content pasted'); }
-            // For more events: 'https://www.froala.com/wysiwyg-editor/docs/events'
-        }
-    }
-    
+    actions: {
+      contentChanged: function(event, editor) {
+        console.log("Content Changed");
+        console.log(event);
+        console.log(editor);
+      },
+      focus: function(event, editor) {
+        console.log("Focus");
+        console.log(event);
+        console.log(editor);
+      },
+    },
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,1 @@
-{{froala-editor params=froalaEditor.params value=value events=froalaEditor.events}}
+{{froala-editor params=froalaEditor.params value=value focus="focus" contentChanged=(action "contentChanged")}}


### PR DESCRIPTION
In Ember, handling jQuery events is not normal. We usually go through Ember actions. Also, in handling the events the way that was recommended, unfortunately the context is not correct. If you used the original code, you couldn't set a variable on the controller or component where you were using the component because the context of the function was incorrect. In my attempt to resolve that, I found this solution to be ideal.

Pros:
- Allows Ember users to interact the way they would normally interact with a component. Actions are nice!
- Allows us to only listen to events that the users chooses to handle still
- The user doesn't have to worry about context.

Cons:
- The list of events has to be updated if new ones are added. I couldn't find a way around this without requiring that anytime you want to use an event you do something like `event-contentChanged` and we could look through `this.attr` for anything that starts with `event`. That seems like overkill.

Any thoughts are appreciated!
