### PR TITLE
Feature/code clean up

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -5,130 +5,130 @@ const { $, on } = Ember;
 const { isFunction, proxy } = $;
 
 export default Ember.Component.extend({
-    layout: layout,
-    params: {},
-    tagName: 'div',
-    value: null,
-    _froala: null,
+  layout: layout,
+  params: {},
+  tagName: 'div',
+  value: null,
+  _froala: null,
 
-    eventNames: [
-      'afterFileUpload',
-      'afterImageUpload',
-      'afterPaste',
-      'afterPasteCleanup',
-      'afterRemoveImage',
-      'afterSave',
-      'afterUploadPastedImage',
-      'align',
-      'backColor',
-      'badLink',
-      'beforeDeleteImage',
-      'beforeFileUpload',
-      'beforeImageUpload',
-      'beforePaste',
-      'beforeRemoveImage',
-      'beforeSave',
-      'beforeUploadPastedImage',
-      'blur',
-      'bold',
-      'cellDeleted',
-      'cellHorizontalSplit',
-      'cellInsertedAfter',
-      'cellInsertedBefore',
-      'cellVerticalSplit',
-      'cellsMerged',
-      'columnDeleted',
-      'columnInsertedAfter',
-      'columnInsertedBefore',
-      'contentChanged',
-      'fileError',
-      'fileUploaded',
-      'focus',
-      'fontFamily',
-      'fontSize',
-      'foreColor',
-      'formatBlock',
-      'getHTML',
-      'htmlHide',
-      'htmlShow',
-      'imageAltSet',
-      'imageDeleteError',
-      'imageDeleteSuccess',
-      'imageError',
-      'imageFloatedLeft',
-      'imageFloatedNone',
-      'imageFloatedRight',
-      'imageInserted',
-      'imageLinkInserted',
-      'imageLinkRemoved',
-      'imageLoaded',
-      'imageReplaced',
-      'imageResize',
-      'imageResizeEnd',
-      'imagesLoaded',
-      'imagesLoadError',
-      'indent',
-      'initialized',
-      'italic',
-      'linkInserted',
-      'linkRemoved',
-      'maxCharNumberExceeded',
-      'onPaste',
-      'orderedListInserted',
-      'outdent',
-      'redo',
-      'rowDeleted',
-      'rowInsertedAbove',
-      'rowInsertedBelow',
-      'saveError',
-      'selectAll',
-      'strikeThrough',
-      'subscript',
-      'superscript',
-      'tableDeleted',
-      'tableInserted',
-      'underline',
-      'undo',
-      'unorderedListInserted',
-      'videoError',
-      'videoFloatedLeft',
-      'videoFloatedNone',
-      'videoFloatedRight',
-      'videoInserted',
-      'videoRemoved',
-    ],
+  eventNames: [
+    'afterFileUpload',
+    'afterImageUpload',
+    'afterPaste',
+    'afterPasteCleanup',
+    'afterRemoveImage',
+    'afterSave',
+    'afterUploadPastedImage',
+    'align',
+    'backColor',
+    'badLink',
+    'beforeDeleteImage',
+    'beforeFileUpload',
+    'beforeImageUpload',
+    'beforePaste',
+    'beforeRemoveImage',
+    'beforeSave',
+    'beforeUploadPastedImage',
+    'blur',
+    'bold',
+    'cellDeleted',
+    'cellHorizontalSplit',
+    'cellInsertedAfter',
+    'cellInsertedBefore',
+    'cellVerticalSplit',
+    'cellsMerged',
+    'columnDeleted',
+    'columnInsertedAfter',
+    'columnInsertedBefore',
+    'contentChanged',
+    'fileError',
+    'fileUploaded',
+    'focus',
+    'fontFamily',
+    'fontSize',
+    'foreColor',
+    'formatBlock',
+    'getHTML',
+    'htmlHide',
+    'htmlShow',
+    'imageAltSet',
+    'imageDeleteError',
+    'imageDeleteSuccess',
+    'imageError',
+    'imageFloatedLeft',
+    'imageFloatedNone',
+    'imageFloatedRight',
+    'imageInserted',
+    'imageLinkInserted',
+    'imageLinkRemoved',
+    'imageLoaded',
+    'imageReplaced',
+    'imageResize',
+    'imageResizeEnd',
+    'imagesLoaded',
+    'imagesLoadError',
+    'indent',
+    'initialized',
+    'italic',
+    'linkInserted',
+    'linkRemoved',
+    'maxCharNumberExceeded',
+    'onPaste',
+    'orderedListInserted',
+    'outdent',
+    'redo',
+    'rowDeleted',
+    'rowInsertedAbove',
+    'rowInsertedBelow',
+    'saveError',
+    'selectAll',
+    'strikeThrough',
+    'subscript',
+    'superscript',
+    'tableDeleted',
+    'tableInserted',
+    'underline',
+    'undo',
+    'unorderedListInserted',
+    'videoError',
+    'videoFloatedLeft',
+    'videoFloatedNone',
+    'videoFloatedRight',
+    'videoInserted',
+    'videoRemoved',
+  ],
 
-    handleFroalaEvent: function(event, editor) {
-      const eventName = event.namespace;
-      const actionHandler = this.attrs[eventName];
+  handleFroalaEvent: function(event, editor) {
+    const eventName = event.namespace;
+    const actionHandler = this.attrs[eventName];
 
-      if (isFunction(actionHandler)) {
-        actionHandler(event, editor);
-      } else {
-        this.sendAction(eventName, event, editor);
+    if (isFunction(actionHandler)) {
+      actionHandler(event, editor);
+    } else {
+      this.sendAction(eventName, event, editor);
+    }
+  },
+
+  renderFroalaEditor: on('didInsertElement', function() {
+    const events = this.get('eventNames');
+    const froala = this.$().editable(this.get('params'));
+    const froalaElement = this.$();
+
+    froalaElement.editable('setHTML', this.get('value') || '', false);
+
+    events.forEach((key) => {
+      if (this.attrs[key]) {
+        froalaElement.on('editable.' + key, proxy(this.handleFroalaEvent, this));
       }
-    },
+    });
 
-    renderFroalaEditor: on('didInsertElement', function() {
-      const events = this.get('eventNames');
-      const froala = this.$().editable(this.get('params'));
-      const froalaElement = this.$();
+    this.set('_froala', froala);
+  }),
 
-      froalaElement.editable('setHTML', this.get('value') || '', false);
-
-      events.forEach((key) => {
-        if (this.attrs[key]) {
-          froalaElement.on('editable.' + key, proxy(this.handleFroalaEvent, this));
-        }
-      });
-
-      this.set('_froala', froala);
-    }),
-
-    teardownFroalaEditor: on('willDestroyElement', function() {
-      if (this.get('_froala')) {
-        this.$().editable('destroy');
-      }
-    }),
+  teardownFroalaEditor: on('willDestroyElement', function() {
+    if (this.get('_froala')) {
+      this.$().editable('destroy');
+    }
+  }),
 
 });

--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -1,14 +1,15 @@
 import Ember from 'ember';
 import layout from '../templates/components/froala-editor';
+
 const { isFunction, proxy } = Ember.$;
 
 export default Ember.Component.extend({
     layout: layout,
-
-    tagName: 'div',
-    _froala: null,
     params: {},
+    tagName: 'div',
     value: null,
+    _froala: null,
+
     eventNames: [
       'afterFileUpload',
       'afterImageUpload',
@@ -97,25 +98,26 @@ export default Ember.Component.extend({
     ],
 
     didInsertElement: function() {
-        var froala = this.$().editable(this.get('params')),
-            events = this.get('eventNames');
+      const events = this.get('eventNames');
+      const froala = this.$().editable(this.get('params'));
+      const froalaElement = this.$();
 
-        const froalaElement = this.$();
-        froalaElement.editable('setHTML', this.get('value') || '', false);
+      froalaElement.editable('setHTML', this.get('value') || '', false);
 
-        events.forEach((key) => {
-          if(this.attrs[key]) {
-            froalaElement.on('editable.'+key, proxy(this.handleFroalaEvent, this));
-          }
-        });
+      events.forEach((key) => {
+        if (this.attrs[key]) {
+          froalaElement.on('editable.' + key, proxy(this.handleFroalaEvent, this));
+        }
+      });
 
-        this.set('_froala', froala);
+      this.set('_froala', froala);
     },
 
     handleFroalaEvent: function(event, editor) {
       const eventName = event.namespace;
       const actionHandler = this.attrs[eventName];
-      if(isFunction(actionHandler)) {
+
+      if (isFunction(actionHandler)) {
         actionHandler(event, editor);
       } else {
         this.sendAction(eventName, event, editor);
@@ -123,9 +125,9 @@ export default Ember.Component.extend({
     },
 
     willDestroyElement: function() {
-        if (this.get('_froala')) {
-            this.$().editable('destroy');
-        }
+      if (this.get('_froala')) {
+        this.$().editable('destroy');
+      }
     }
 });
 

--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import layout from '../templates/components/froala-editor';
 
-const { isFunction, proxy } = Ember.$;
+const { $, on } = Ember;
+const { isFunction, proxy } = $;
 
 export default Ember.Component.extend({
     layout: layout,
@@ -97,7 +98,18 @@ export default Ember.Component.extend({
       'videoRemoved',
     ],
 
-    didInsertElement: function() {
+    handleFroalaEvent: function(event, editor) {
+      const eventName = event.namespace;
+      const actionHandler = this.attrs[eventName];
+
+      if (isFunction(actionHandler)) {
+        actionHandler(event, editor);
+      } else {
+        this.sendAction(eventName, event, editor);
+      }
+    },
+
+    renderFroalaEditor: on('didInsertElement', function() {
       const events = this.get('eventNames');
       const froala = this.$().editable(this.get('params'));
       const froalaElement = this.$();
@@ -111,23 +123,12 @@ export default Ember.Component.extend({
       });
 
       this.set('_froala', froala);
-    },
+    }),
 
-    handleFroalaEvent: function(event, editor) {
-      const eventName = event.namespace;
-      const actionHandler = this.attrs[eventName];
-
-      if (isFunction(actionHandler)) {
-        actionHandler(event, editor);
-      } else {
-        this.sendAction(eventName, event, editor);
-      }
-    },
-
-    willDestroyElement: function() {
+    teardownFroalaEditor: on('willDestroyElement', function() {
       if (this.get('_froala')) {
         this.$().editable('destroy');
       }
-    }
-});
+    }),
 
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,7 +16,11 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    }
+    },
+
+    contentSecurityPolicy: {
+      'style-src': "'self' 'unsafe-inline'",
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
This is the first of a couple of PRs I'm hoping to put up. The next will be a functionality PR but this one:
- Fixes browser warnings for the dummy app's CSP
- Cleans up some inconsistent code standards (indentations, `var` and `const`, property order, etc)
- Uses `Ember.on` instead of the component's public methods

Let me know which parts, if any, you'd like to keep. Won't be insulted if you don't want any of it - didn't take much time!
