### PR TITLE
Update froala-editor.js

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -24,14 +24,24 @@ export default Ember.Component.extend({
         this.set('_froala', froala);
     },
 
-    handleFroalaEvent: function(event, editor) {
-      var events = this.get('eventNames');
+    handleFroalaEvent: function(event, editor,x,y,z) {
       const eventName = event.namespace;
       const reverseEventName = eventName.replace(/\./g,"_");
+      const actionHandler = this.attrs[reverseEventName||"image_beforeUpload"];
       if(isFunction(actionHandler)) {
         actionHandler(event, editor);
       } else {
-        this.sendAction(reverseEventName, event, editor);
+        if(eventName=='beforeUpload.image'){
+          var beforeUpload = this.attrs.image_beforeUpload(event, editor,x);
+          if(beforeUpload===false){
+            return false;
+          }
+        }else{
+          var action =  this.attrs[reverseEventName];
+          if(action===false){
+            return false;
+          }
+        }
       }
     },
     willDestroyElement: function() {


### PR DESCRIPTION
handle reverse namespace, and function callback. looking for a better solution on the reverse namespace but may not be one until the next Froala release fixing the issue
